### PR TITLE
fix(#6): 네비게이션 드롭다운 hover 시 다른 item의 dropdown이 펼쳐지는 현상 수정

### DIFF
--- a/src/components/header/Navigation.tsx
+++ b/src/components/header/Navigation.tsx
@@ -1,17 +1,17 @@
-import Dropdown from "../common/Dropdown";
-import { styled } from "styled-components";
 import { Link } from "react-router-dom";
 import { NAVIGATION } from "../../data/navigationItems";
+import Dropdown from "../common/Dropdown";
+import { styled } from "styled-components";
 
 function Navigation() {
   return (
-    <NavigationStyle className="navigation">
+    <NavigationStyle>
       <ul>
         {NAVIGATION.map((item, index) => (
           <li key={index}>
             <Link to={item.link}>{item.title}</Link>
             {item.subItems && (
-              <Dropdown>
+              <Dropdown className="navigation-dropdown">
                 {item.subItems.map((subItem, subIndex) => (
                   <Link to={subItem.link} key={subIndex} className="item">
                     {subItem.title}
@@ -44,84 +44,80 @@ const NavigationStyle = styled.nav`
 
         &:hover {
           color: ${({ theme }) => theme.color.primary};
-
-          > .panel {
-            visibility: visible;
-            transform: scaleY(1);
-            opacity: 1;
-            transition: transform 0.3s ease, opacity 0.3s ease;
-          }
-
-          > a {
-            color: ${({ theme }) => theme.color.primary};
-          }
-        }
-      }
-    }
-
-    .panel {
-      visibility: hidden;
-      display: flex;
-      flex-direction: column;
-
-      position: absolute;
-      top: 100%;
-      margin-top: 1rem;
-      padding: 1rem 1.2rem;
-      line-height: 2;
-
-      background: ${({ theme }) => theme.color.surface};
-      border-radius: ${({ theme }) => theme.borderRadius.default};
-      box-shadow: ${({ theme }) => theme.shadow.default};
-
-      transform-origin: top;
-      transform: scaleY(0);
-      opacity: 0;
-
-      .item {
-        font-size: ${({ theme }) => theme.fontSize.medium};
-        color: ${({ theme }) => theme.color.text};
-        text-decoration: none;
-        transition: color 0.3s ease;
-        border-radius: ${({ theme }) => theme.borderRadius.default};
-        padding: 0.3rem 1rem;
-
-        &:hover {
-          color: ${({ theme }) => theme.color.primary};
-          background: ${({ theme }) => theme.color.secondary};
-          box-shadow: ${({ theme }) => theme.shadow.default};
         }
       }
 
-      /* 화살표 */
-      &:before {
-        content: "";
-        position: absolute;
-        width: 0;
-        height: 0.5rem;
-        border-left: 0.5rem solid transparent;
-        border-right: 0.5rem solid transparent;
-        border-bottom: 0.5rem solid ${({ theme }) => theme.color.surface};
-        top: -0.5rem;
-        left: 2rem;
+      &:hover .navigation-dropdown {
+        visibility: visible;
+        opacity: 1;
+        transform: scaleY(1);
       }
 
-      &:after {
-        content: "";
+      .navigation-dropdown {
+        visibility: hidden;
         position: absolute;
-        top: -1rem;
+        top: calc(100% + 1rem);
         left: 0;
-        width: 100%;
-        height: 2rem;
-        background: none;
-      }
-    }
 
-    &:hover .panel {
-      visibility: visible;
-      transform: scaleY(1);
-      opacity: 1;
-      transition: transform 0.5s ease, opacity 0.3s ease;
+        opacity: 0;
+        transform-origin: top;
+        transform: scaleY(0);
+        display: flex;
+        flex-direction: column;
+        transition: all 0.3s ease;
+
+        .panel {
+          display: flex;
+          flex-direction: column;
+
+          position: relative;
+          top: 100%;
+          padding: 1rem 1.2rem;
+          line-height: 2;
+
+          background: ${({ theme }) => theme.color.surface};
+          border-radius: ${({ theme }) => theme.borderRadius.default};
+          box-shadow: ${({ theme }) => theme.shadow.default};
+
+          .item {
+            font-size: ${({ theme }) => theme.fontSize.medium};
+            color: ${({ theme }) => theme.color.text};
+            text-decoration: none;
+            transition: color 0.3s ease;
+            border-radius: ${({ theme }) => theme.borderRadius.default};
+            padding: 0.3rem 1rem;
+
+            &:hover {
+              color: ${({ theme }) => theme.color.primary};
+              background: ${({ theme }) => theme.color.secondary};
+              box-shadow: ${({ theme }) => theme.shadow.default};
+            }
+          }
+        }
+
+        /* 화살표 */
+        &:before {
+          content: "";
+          position: absolute;
+          width: 0;
+          height: 0.5rem;
+          border-left: 0.5rem solid transparent;
+          border-right: 0.5rem solid transparent;
+          border-bottom: 0.5rem solid ${({ theme }) => theme.color.surface};
+          top: -0.5rem;
+          left: 2rem;
+        }
+
+        &:after {
+          content: "";
+          position: absolute;
+          top: -1rem;
+          left: 0;
+          width: 100%;
+          height: 2rem;
+          background: none;
+        }
+      }
     }
   }
 

--- a/src/components/header/Navigation.tsx
+++ b/src/components/header/Navigation.tsx
@@ -1,7 +1,7 @@
 import Dropdown from "../common/Dropdown";
 import { styled } from "styled-components";
 import { Link } from "react-router-dom";
-import { NAVIGATION } from "../../data/NavigationItems";
+import { NAVIGATION } from "../../data/navigationItems";
 
 function Navigation() {
   return (


### PR DESCRIPTION
## 작업 개요

- 파일명 오타 수정
- 네비게이션 드롭다운 hover 오류 수정 (다른 item의 dropdown이 펼쳐지는 현상)

## 관련 이슈

- Closes #6

## PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정
- [ ] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 주요 변경 사항

1. **파일명 오타 수정**
   - 잘못된 파일명을 올바르게 수정해 import 오류 해결.

2. **네비게이션 드롭다운 hover 오류 수정**
   - `hover` 상태에서 다른 `item`의 드롭다운이 펼쳐지는 오류를 CSS 새로운 className을 사용해 수정.
   - 각 `item`의 드롭다운이 독립적으로 동작하도록 개선.

## 테스트 결과

- 파일명 수정 후 정상적으로 빌드 확인.
- 각 네비게이션 `item`의 드롭다운이 의도대로 동작하는지 수동 테스트 완료.